### PR TITLE
Update group ID for built-in Om nickname

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The result:
 :dependencies [[org.clojure/clojure "1.6.0"]
                [http-kit "2.1.18"]
                [compojure "1.1.8"]
-               [om "0.7.1"]
+               [org.omcljs/om "0.8.8"]
                [org.clojure/core.async "0.1.338.0-5c5012-alpha"]
                [org.clojure/clojurescript "0.0-2311"]
                [org.clojure/core.logic "0.8.8"]]
@@ -162,7 +162,7 @@ groups. Create files containing edn maps such as these:
 
 ;; client-group
 ;; /home/stuartsierra/.plz/client.edn
-{om                              #{"om"}
+{org.omcljs/om                   #{"om"}
  org.clojure/core.async          #{"core.async" "async"}
  org.clojure/clojurescript       #{"clojurescript" "cljs"}}
 ```

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-plz "0.3.1"
+(defproject lein-plz "0.3.2-SNAPSHOT"
   :description "A Leiningen plugin for adding dependencies to projects quickly."
   :url "http://johnwalker.io/projects/lein-plz.html"
   :license {:name "Eclipse Public License"

--- a/src/leiningen/plz/deps.clj
+++ b/src/leiningen/plz/deps.clj
@@ -201,7 +201,6 @@
     noencore                                     #{"noencore"}
     noir                                         #{"noir"}
     ns-tracker                                   #{"ns-tracker"}
-    om                                           #{"om"}
     onelog                                       #{"onelog"}
     optimus                                      #{"optimus"}
     ordered                                      #{"ordered"}
@@ -416,6 +415,7 @@
     org.immutant/deploy-tools                    #{"deploy-tools"}
     org.maravillas/ring-core-gae                 #{"ring-core-gae"}
     org.markdownj/markdownj                      #{"markdownj"}
+    org.omcljs/om                                #{"om"}
     org.ozias.cljlibs/scm                        #{"scm"}
     org.ozias.cljlibs/shell                      #{"shell"}
     org.scribe/scribe                            #{"scribe"}


### PR DESCRIPTION
As of version [0.8.2](https://github.com/omcljs/om/commit/e10d60222725cf3660832b75bbd30cb95d25b3bb), Om artifacts are [deployed to Clojars](https://clojars.org/org.omcljs/om) as `[org.omcljs/om "x.y.z"]`. This patch is kind of trivial but will ensure that lein-plz continues to default to the most up-to-date version of Om available.