### PR TITLE
Add CrossClj search fallback

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-plz "0.3.3"
+(defproject lein-plz "0.3.4-SNAPSHOT"
   :description "A Leiningen plugin for adding dependencies to projects quickly."
   :url "http://johnwalker.io/"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
This is a minimally invasive implementation of the strategy discussed in issue #1. Currently this doesn't cache the CrossClj index to disk because caching feels inessential to the solution and adds a bunch of complexity to the code – I can go back in and make a separate commit to implement caching if you think it's necessary.
